### PR TITLE
feat: Add explicit command nodes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -59,7 +59,7 @@ module.exports = grammar({
     // to mean "scale the number by 1024", "by 1024x1024", etc."
     integer: ($) => /\d+[kmgtpezyKMGTPEZY]?/,
 
-    string: ($) => choice($._shell_command_string, repeat1($._string_particle)),
+    string: ($) => choice($._shell_command_string, repeat1($._string_fragment)),
 
     _shell_command_string: ($) =>
       seq(
@@ -71,10 +71,10 @@ module.exports = grammar({
           // foo = "!..."
           seq('"', $.shell_command, $._quoted_string_content, '"')
         ),
-        repeat($._string_particle)
+        repeat($._string_fragment)
       ),
 
-    _string_particle: ($) =>
+    _string_fragment: ($) =>
       choice($._quoted_string, $._unquoted_string, $._line_continuation),
 
     _quoted_string: ($) => seq('"', optional($._quoted_string_content), '"'),

--- a/grammar.js
+++ b/grammar.js
@@ -59,19 +59,32 @@ module.exports = grammar({
     // to mean "scale the number by 1024", "by 1024x1024", etc."
     integer: ($) => /\d+[kmgtpezyKMGTPEZY]?/,
 
-    string: ($) =>
-      repeat1(
-        choice($._quoted_string, $._unquoted_string, $._line_continuation)
-      ),
+    string: ($) => choice($._shell_command_string, repeat1($._string_particle)),
 
-    _quoted_string: ($) =>
+    _shell_command_string: ($) =>
       seq(
-        '"',
-        repeat(choice(/[^\"]/, $.escape_sequence, $._line_continuation)),
-        '"'
+        choice(
+          // foo = !"..."
+          seq($.shell_command, $._quoted_string),
+          // foo = !...
+          seq($.shell_command, $._unquoted_string),
+          // foo = "!..."
+          seq('"', $.shell_command, $._quoted_string_content, '"')
+        ),
+        repeat($._string_particle)
       ),
 
-    _unquoted_string: ($) => /[^\r\n;#" \t\f\v\\][^\r\n;#"\\]*/,
+    _string_particle: ($) =>
+      choice($._quoted_string, $._unquoted_string, $._line_continuation),
+
+    _quoted_string: ($) => seq('"', optional($._quoted_string_content), '"'),
+
+    _quoted_string_content: ($) =>
+      repeat1(choice(/[^\"]/, $.escape_sequence, $._line_continuation)),
+
+    _unquoted_string: ($) => choice(/[^\r\n;#" \t\f\v\\!][^\r\n;#"\\]*/, "!"),
+
+    shell_command: ($) => prec(2, "!"),
 
     escape_sequence: ($) => /\\([btnfr"\\]|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})/,
 

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -307,10 +307,12 @@ comment characters within strings
       (section_name))
     (variable
       (name)
-      (string))
+      (string
+        (shell_command)))
     (variable
       (name)
       (string
+        (shell_command)
         (escape_sequence)
         (escape_sequence)))))
 
@@ -370,6 +372,45 @@ empty string
   (section
     (section_header
       (section_name))
+    (variable
+      (name)
+      (string))))
+
+================================================================================
+shell commands
+================================================================================
+[foo]
+    a = !"echo ok"
+    b = "!echo ok"
+    c = !echo ok
+    d = "echo" !"fail"
+    e = echo "!fail"
+    f = echo fail !
+
+--------------------------------------------------------------------------------
+
+(config
+  (section
+    (section_header
+      (section_name))
+    (variable
+      (name)
+      (string
+        (shell_command)))
+    (variable
+      (name)
+      (string
+        (shell_command)))
+    (variable
+      (name)
+      (string
+        (shell_command)))
+    (variable
+      (name)
+      (string))
+    (variable
+      (name)
+      (string))
     (variable
       (name)
       (string))))


### PR DESCRIPTION
to distinguish regular strings from shell commands. The latter, once identified, can use language injections to highlight as proper bash code rather than regular strings, for example.

In order to maintain compatibility with existing code, the grammar is extended such that the `string` node is kept as is, but a field `shell_command` is added in case it is a valid shell command (as git-config defines it).

Closes: #12