### PR TITLE
Allow escape sequences outside of quoted strings

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -75,12 +75,20 @@ module.exports = grammar({
       ),
 
     _string_fragment: ($) =>
-      choice($._quoted_string, $._unquoted_string, $._line_continuation),
+      choice(
+        $._quoted_string,
+        $._unquoted_string,
+        $.escape_sequence,
+        $._line_continuation
+      ),
 
     _quoted_string: ($) => seq('"', optional($._quoted_string_content), '"'),
 
+    // The fallback class excludes newlines so that an unterminated quoted
+    // string cannot swallow the rest of the file. Multi-line quoted values
+    // are still supported via the explicit `_line_continuation` branch.
     _quoted_string_content: ($) =>
-      repeat1(choice(/[^\"]/, $.escape_sequence, $._line_continuation)),
+      repeat1(choice(/[^\"\r\n]/, $.escape_sequence, $._line_continuation)),
 
     _unquoted_string: ($) => choice(/[^\r\n;#" \t\f\v\\!][^\r\n;#"\\]*/, "!"),
 

--- a/test/corpus/main.txt
+++ b/test/corpus/main.txt
@@ -415,3 +415,46 @@ shell commands
       (name)
       (string))))
 
+
+================================================================================
+escaped quotes in an unquoted value
+================================================================================
+[pretty]
+	ref = %h \"%s\"
+[user]
+	name = Lyall
+
+--------------------------------------------------------------------------------
+
+(config
+  (section
+    (section_header
+      (section_name))
+    (variable
+      (name)
+      (string
+        (escape_sequence)
+        (escape_sequence))))
+  (section
+    (section_header
+      (section_name))
+    (variable
+      (name)
+      (string))))
+
+================================================================================
+escaped quote between unquoted characters
+================================================================================
+[foo]
+	bar = a\"b
+
+--------------------------------------------------------------------------------
+
+(config
+  (section
+    (section_header
+      (section_name))
+    (variable
+      (name)
+      (string
+        (escape_sequence)))))


### PR DESCRIPTION
The grammar currently has a bug regarding escape sequences. They're only considered inside of double quotes, when really they're allowed anywhere in a git config value. git's own `parse_value()` treats `\` as an escape regardless of position. 

So the following valid config causes a parse error:

```
[pretty]
	ref = %h \"%s\"
```

The grammar only reached `escape_sequence` from `_quoted_string_content`, so a backslash in an unquoted value was a parse error. The stray `"` then opened a quoted string whose fallback class `/[^\"]/` matched newlines, swallowing every following line up to the next quote in the file and breaking highlighting for the rest of it.

How we can fix this:

- Add `escape_sequence` to `_string_fragment` so escapes parse in unquoted values.
- Tighten `_quoted_string_content`'s fallback to `/[^\"\r\n]/` so an unterminated quoted string can no longer consume subsequent lines (multi-line values still work via `_line_continuation`).

Also added test cases covering this